### PR TITLE
v0.15.1

### DIFF
--- a/docs/modules/kuber.tests.scenarios.port_int_or_string.rst
+++ b/docs/modules/kuber.tests.scenarios.port_int_or_string.rst
@@ -1,0 +1,21 @@
+kuber.tests.scenarios.port\_int\_or\_string package
+===================================================
+
+Submodules
+----------
+
+kuber.tests.scenarios.port\_int\_or\_string.test\_pod\_int\_or\_string module
+-----------------------------------------------------------------------------
+
+.. automodule:: kuber.tests.scenarios.port_int_or_string.test_pod_int_or_string
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: kuber.tests.scenarios.port_int_or_string
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/modules/kuber.tests.scenarios.rst
+++ b/docs/modules/kuber.tests.scenarios.rst
@@ -14,6 +14,7 @@ Subpackages
    kuber.tests.scenarios.get_containers_from_job
    kuber.tests.scenarios.metadata_owner_reference
    kuber.tests.scenarios.odd_api_versions
+   kuber.tests.scenarios.port_int_or_string
    kuber.tests.scenarios.same_names_different_resources
    kuber.tests.scenarios.value_casting
    kuber.tests.scenarios.zero_scale_deployment

--- a/kuber/__init__.py
+++ b/kuber/__init__.py
@@ -22,7 +22,7 @@ from kuber.management.creation import new_resource  # noqa: F401
 from kuber.versioning import KubernetesVersion  # noqa: F401
 
 #: kuber library version.
-__version__ = "1.15.0"
+__version__ = "1.15.1"
 
 #: The loader used when loading yaml via pyyaml. This can be overridden
 #: in cases where a different Loader is preferred.

--- a/kuber/_types.py
+++ b/kuber/_types.py
@@ -1,0 +1,18 @@
+import typing
+
+
+def integer_or_string(value: typing.Any) -> typing.Union[None, int, str]:
+    """Conversion for int_or_string types."""
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str):
+        return value
+
+    try:
+        return int(value)
+    except ValueError:
+        return str(value)

--- a/kuber/definitions/_support.py
+++ b/kuber/definitions/_support.py
@@ -1,6 +1,7 @@
 import typing
 
 from kuber.definitions import _abstracts
+from kuber import _types
 
 
 def serialize_property(value: typing.Any) -> typing.Any:
@@ -50,6 +51,9 @@ def deserialize_property(value: typing.Any, data_type: tuple) -> typing.Any:
     """
     if value is None:
         return None
+
+    if data_type[0] == _types.integer_or_string:
+        return _types.integer_or_string(value)
 
     if issubclass(data_type[0], _abstracts.Definition):
         return data_type[0]().from_dict(value)

--- a/kuber/latest/__init__.py
+++ b/kuber/latest/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="1",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="c4d752765b3bbac2237bf87cf0b1c2e307844666",
 )

--- a/kuber/latest/admissionregistration_v1.py
+++ b/kuber/latest/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/admissionregistration_v1beta1.py
+++ b/kuber/latest/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/apiextensions_v1.py
+++ b/kuber/latest/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/apiextensions_v1beta1.py
+++ b/kuber/latest/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/apimachinery_runtime.py
+++ b/kuber/latest/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/latest/apimachinery_version.py
+++ b/kuber/latest/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/latest/apiregistration_v1.py
+++ b/kuber/latest/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/apiregistration_v1beta1.py
+++ b/kuber/latest/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/apiserverinternal_v1alpha1.py
+++ b/kuber/latest/apiserverinternal_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/apps_v1.py
+++ b/kuber/latest/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import Container  # noqa: F401
 from kuber.latest.core_v1 import ContainerPort  # noqa: F401
 from kuber.latest.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/latest/authentication_v1.py
+++ b/kuber/latest/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/authentication_v1beta1.py
+++ b/kuber/latest/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/authorization_v1.py
+++ b/kuber/latest/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/authorization_v1beta1.py
+++ b/kuber/latest/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/autoscaling_v1.py
+++ b/kuber/latest/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/autoscaling_v2beta1.py
+++ b/kuber/latest/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
@@ -50,7 +51,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
             "container": (str, None),
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -131,7 +132,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ContainerResourceMetricSource":
         return self
@@ -175,7 +176,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         self._types = {
             "container": (str, None),
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -246,7 +247,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:
@@ -396,8 +397,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -456,7 +457,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -473,7 +474,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -510,8 +511,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -531,7 +532,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -548,7 +549,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1941,11 +1942,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2049,7 +2050,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -2085,8 +2086,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -2107,7 +2108,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -2124,7 +2125,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2233,7 +2234,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2298,7 +2299,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -2332,7 +2333,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2352,7 +2353,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2442,7 +2443,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2504,7 +2505,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2545,7 +2546,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2597,7 +2598,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/latest/autoscaling_v2beta2.py
+++ b/kuber/latest/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
@@ -2208,9 +2209,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2251,7 +2252,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -2285,7 +2286,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2318,8 +2319,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2360,7 +2361,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2375,7 +2376,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/latest/batch_v1.py
+++ b/kuber/latest/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import Container  # noqa: F401
 from kuber.latest.core_v1 import ContainerPort  # noqa: F401
 from kuber.latest.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/latest/batch_v1beta1.py
+++ b/kuber/latest/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import Container  # noqa: F401
 from kuber.latest.core_v1 import ContainerPort  # noqa: F401
 from kuber.latest.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/latest/batch_v2alpha1.py
+++ b/kuber/latest/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import Container  # noqa: F401
 from kuber.latest.core_v1 import ContainerPort  # noqa: F401
 from kuber.latest.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/latest/certificates_v1.py
+++ b/kuber/latest/certificates_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/certificates_v1beta1.py
+++ b/kuber/latest/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/coordination_v1.py
+++ b/kuber/latest/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import MicroTime  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/coordination_v1beta1.py
+++ b/kuber/latest/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import MicroTime  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/core_v1.py
+++ b/kuber/latest/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import Condition  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
@@ -5322,7 +5323,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5373,7 +5374,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -9056,7 +9057,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9126,14 +9127,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9142,7 +9145,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22971,7 +22974,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -23007,7 +23010,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26601,7 +26604,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26734,7 +26737,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26747,8 +26750,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26764,7 +26769,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -28071,7 +28076,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -28092,14 +28097,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -28108,7 +28115,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/latest/custom_v1.py
+++ b/kuber/latest/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/discovery_v1beta1.py
+++ b/kuber/latest/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/latest/events_v1.py
+++ b/kuber/latest/events_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import EventSource  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/latest/events_v1beta1.py
+++ b/kuber/latest/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.core_v1 import EventSource  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/latest/extensions_v1beta1.py
+++ b/kuber/latest/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/latest/flowcontrol_v1alpha1.py
+++ b/kuber/latest/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/flowcontrol_v1beta1.py
+++ b/kuber/latest/flowcontrol_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.meta_v1 import Status  # noqa: F401

--- a/kuber/latest/meta_v1.py
+++ b/kuber/latest/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/latest/networking_v1.py
+++ b/kuber/latest/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.core_v1 import LoadBalancerStatus  # noqa: F401
@@ -2286,19 +2287,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -2307,7 +2310,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/latest/networking_v1beta1.py
+++ b/kuber/latest/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/latest/node_v1.py
+++ b/kuber/latest/node_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import Toleration  # noqa: F401

--- a/kuber/latest/node_v1alpha1.py
+++ b/kuber/latest/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import Toleration  # noqa: F401

--- a/kuber/latest/node_v1beta1.py
+++ b/kuber/latest/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import Toleration  # noqa: F401

--- a/kuber/latest/policy_v1beta1.py
+++ b/kuber/latest/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/latest/rbac_v1.py
+++ b/kuber/latest/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/rbac_v1alpha1.py
+++ b/kuber/latest/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/rbac_v1beta1.py
+++ b/kuber/latest/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import LabelSelector  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/latest/scheduling_v1.py
+++ b/kuber/latest/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/latest/scheduling_v1alpha1.py
+++ b/kuber/latest/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/latest/scheduling_v1beta1.py
+++ b/kuber/latest/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/latest/storage_v1.py
+++ b/kuber/latest/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/latest/storage_v1alpha1.py
+++ b/kuber/latest/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/latest/storage_v1beta1.py
+++ b/kuber/latest/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.latest.meta_v1 import ListMeta  # noqa: F401
 from kuber.latest.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.latest.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/pre/__init__.py
+++ b/kuber/pre/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="0",
     pre_release="alpha.0",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="98bc258bf5516b6c60860e06845b899eab29825d",
 )

--- a/kuber/pre/admissionregistration_v1.py
+++ b/kuber/pre/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/admissionregistration_v1beta1.py
+++ b/kuber/pre/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/apiextensions_v1.py
+++ b/kuber/pre/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/apiextensions_v1beta1.py
+++ b/kuber/pre/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/apimachinery_runtime.py
+++ b/kuber/pre/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/pre/apimachinery_version.py
+++ b/kuber/pre/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/pre/apiregistration_v1.py
+++ b/kuber/pre/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/apiregistration_v1beta1.py
+++ b/kuber/pre/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/apiserverinternal_v1alpha1.py
+++ b/kuber/pre/apiserverinternal_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/apps_v1.py
+++ b/kuber/pre/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import Container  # noqa: F401
 from kuber.pre.core_v1 import ContainerPort  # noqa: F401
 from kuber.pre.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/pre/authentication_v1.py
+++ b/kuber/pre/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/authentication_v1beta1.py
+++ b/kuber/pre/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/authorization_v1.py
+++ b/kuber/pre/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/authorization_v1beta1.py
+++ b/kuber/pre/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/autoscaling_v1.py
+++ b/kuber/pre/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/autoscaling_v2beta1.py
+++ b/kuber/pre/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
@@ -50,7 +51,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
             "container": (str, None),
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -131,7 +132,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ContainerResourceMetricSource":
         return self
@@ -175,7 +176,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         self._types = {
             "container": (str, None),
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -246,7 +247,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:
@@ -396,8 +397,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -456,7 +457,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -473,7 +474,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -510,8 +511,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -531,7 +532,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -548,7 +549,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1941,11 +1942,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2049,7 +2050,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -2085,8 +2086,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -2107,7 +2108,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -2124,7 +2125,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2233,7 +2234,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2298,7 +2299,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -2332,7 +2333,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2352,7 +2353,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2442,7 +2443,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2504,7 +2505,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2545,7 +2546,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2597,7 +2598,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/pre/autoscaling_v2beta2.py
+++ b/kuber/pre/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
@@ -2208,9 +2209,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2251,7 +2252,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -2285,7 +2286,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2318,8 +2319,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2360,7 +2361,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2375,7 +2376,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/pre/batch_v1.py
+++ b/kuber/pre/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import Container  # noqa: F401
 from kuber.pre.core_v1 import ContainerPort  # noqa: F401
 from kuber.pre.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/pre/batch_v1beta1.py
+++ b/kuber/pre/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import Container  # noqa: F401
 from kuber.pre.core_v1 import ContainerPort  # noqa: F401
 from kuber.pre.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/pre/batch_v2alpha1.py
+++ b/kuber/pre/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import Container  # noqa: F401
 from kuber.pre.core_v1 import ContainerPort  # noqa: F401
 from kuber.pre.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/pre/certificates_v1.py
+++ b/kuber/pre/certificates_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/certificates_v1beta1.py
+++ b/kuber/pre/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/coordination_v1.py
+++ b/kuber/pre/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import MicroTime  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/coordination_v1beta1.py
+++ b/kuber/pre/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import MicroTime  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/core_v1.py
+++ b/kuber/pre/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import Condition  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
@@ -5322,7 +5323,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5373,7 +5374,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -9056,7 +9057,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9126,14 +9127,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9142,7 +9145,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22971,7 +22974,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -23007,7 +23010,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26601,7 +26604,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26734,7 +26737,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26747,8 +26750,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26764,7 +26769,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -28071,7 +28076,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -28092,14 +28097,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -28108,7 +28115,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/pre/custom_v1.py
+++ b/kuber/pre/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/discovery_v1beta1.py
+++ b/kuber/pre/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/pre/events_v1.py
+++ b/kuber/pre/events_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import EventSource  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/pre/events_v1beta1.py
+++ b/kuber/pre/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.core_v1 import EventSource  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/pre/extensions_v1beta1.py
+++ b/kuber/pre/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/pre/flowcontrol_v1alpha1.py
+++ b/kuber/pre/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/flowcontrol_v1beta1.py
+++ b/kuber/pre/flowcontrol_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.meta_v1 import Status  # noqa: F401

--- a/kuber/pre/meta_v1.py
+++ b/kuber/pre/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/pre/networking_v1.py
+++ b/kuber/pre/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.core_v1 import LoadBalancerStatus  # noqa: F401
@@ -2286,19 +2287,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -2307,7 +2310,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/pre/networking_v1beta1.py
+++ b/kuber/pre/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/pre/node_v1.py
+++ b/kuber/pre/node_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import Toleration  # noqa: F401

--- a/kuber/pre/node_v1alpha1.py
+++ b/kuber/pre/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import Toleration  # noqa: F401

--- a/kuber/pre/node_v1beta1.py
+++ b/kuber/pre/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import Toleration  # noqa: F401

--- a/kuber/pre/policy_v1beta1.py
+++ b/kuber/pre/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/pre/rbac_v1.py
+++ b/kuber/pre/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/rbac_v1alpha1.py
+++ b/kuber/pre/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/rbac_v1beta1.py
+++ b/kuber/pre/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import LabelSelector  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/pre/scheduling_v1.py
+++ b/kuber/pre/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/pre/scheduling_v1alpha1.py
+++ b/kuber/pre/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/pre/scheduling_v1beta1.py
+++ b/kuber/pre/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/pre/storage_v1.py
+++ b/kuber/pre/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/pre/storage_v1alpha1.py
+++ b/kuber/pre/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/pre/storage_v1beta1.py
+++ b/kuber/pre/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.pre.meta_v1 import ListMeta  # noqa: F401
 from kuber.pre.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.pre.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/tests/scenarios/port_int_or_string/pod.yaml
+++ b/kuber/tests/scenarios/port_int_or_string/pod.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - args:
+    - --configmap
+    - workflow-controller-configmap
+    - --executor-image
+    - argoproj/argoexec:v2.12.3
+    command:
+    - workflow-controller
+    image: argoproj/workflow-controller:v2.12.3
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: metrics
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    name: workflow-controller
+    ports:
+    - containerPort: 9090
+      name: metrics
+  nodeSelector:
+    kubernetes.io/os: linux
+  securityContext:
+    runAsNonRoot: true
+  serviceAccountName: argo

--- a/kuber/tests/scenarios/port_int_or_string/test_pod_int_or_string.py
+++ b/kuber/tests/scenarios/port_int_or_string/test_pod_int_or_string.py
@@ -1,0 +1,13 @@
+import pathlib
+import typing
+
+import kuber
+from kuber.latest import core_v1
+
+directory = pathlib.Path(__file__).parent.absolute()
+
+
+def test_pod_int_or_string():
+    """Should handle a port string value that cannot be an integer."""
+    pod = typing.cast(core_v1.Pod, kuber.from_yaml_file(directory.joinpath("pod.yaml")))
+    assert pod.get_containers()[0].liveness_probe.http_get.port == "metrics"

--- a/kuber/v1_15/__init__.py
+++ b/kuber/v1_15/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="12",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="e2a822d9f3c2fdb5c9bfbe64313cf9f657f0a725",
 )

--- a/kuber/v1_15/admissionregistration_v1beta1.py
+++ b/kuber/v1_15/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/apiextensions_v1beta1.py
+++ b/kuber/v1_15/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/apimachinery_runtime.py
+++ b/kuber/v1_15/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_15/apimachinery_version.py
+++ b/kuber/v1_15/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_15/apiregistration_v1.py
+++ b/kuber/v1_15/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/apiregistration_v1beta1.py
+++ b/kuber/v1_15/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/apps_v1.py
+++ b/kuber/v1_15/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401
@@ -4089,11 +4090,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4110,8 +4111,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4131,7 +4134,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4159,12 +4162,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4179,8 +4182,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4198,10 +4203,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4215,8 +4220,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4233,7 +4240,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_15/apps_v1beta1.py
+++ b/kuber/v1_15/apps_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401
@@ -1916,12 +1917,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -1936,8 +1937,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -1955,10 +1958,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -1972,8 +1975,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -1990,7 +1995,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_15/apps_v1beta2.py
+++ b/kuber/v1_15/apps_v1beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401
@@ -4103,11 +4104,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4124,8 +4125,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4145,7 +4148,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4173,12 +4176,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4193,8 +4196,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4212,10 +4217,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4229,8 +4234,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4247,7 +4254,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_15/auditregistration_v1alpha1.py
+++ b/kuber/v1_15/auditregistration_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/authentication_v1.py
+++ b/kuber/v1_15/authentication_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/authentication_v1beta1.py
+++ b/kuber/v1_15/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/authorization_v1.py
+++ b/kuber/v1_15/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/authorization_v1beta1.py
+++ b/kuber/v1_15/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/autoscaling_v1.py
+++ b/kuber/v1_15/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/autoscaling_v2beta1.py
+++ b/kuber/v1_15/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
@@ -136,8 +137,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -196,7 +197,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -213,7 +214,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -250,8 +251,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -271,7 +272,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -288,7 +289,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1581,11 +1582,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1603,7 +1604,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1689,7 +1690,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -1725,8 +1726,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -1747,7 +1748,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -1764,7 +1765,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1873,7 +1874,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1938,7 +1939,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -1972,7 +1973,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -1992,7 +1993,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2082,7 +2083,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2144,7 +2145,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2185,7 +2186,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2237,7 +2238,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_15/autoscaling_v2beta2.py
+++ b/kuber/v1_15/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
@@ -1576,9 +1577,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1619,7 +1620,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -1653,7 +1654,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -1686,8 +1687,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1728,7 +1729,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -1743,7 +1744,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_15/batch_v1.py
+++ b/kuber/v1_15/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_15/batch_v1beta1.py
+++ b/kuber/v1_15/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_15/batch_v2alpha1.py
+++ b/kuber/v1_15/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_15/certificates_v1beta1.py
+++ b/kuber/v1_15/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/coordination_v1.py
+++ b/kuber/v1_15/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/coordination_v1beta1.py
+++ b/kuber/v1_15/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/core_v1.py
+++ b/kuber/v1_15/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import MicroTime  # noqa: F401
@@ -5210,7 +5211,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5261,7 +5262,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -8071,7 +8072,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -8141,14 +8142,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -8157,7 +8160,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -21210,7 +21213,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -21246,7 +21249,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -24679,7 +24682,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -24775,7 +24778,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -24788,8 +24791,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -24805,7 +24810,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -25774,7 +25779,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -25795,14 +25800,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -25811,7 +25818,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_15/custom_v1.py
+++ b/kuber/v1_15/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_15/events_v1beta1.py
+++ b/kuber/v1_15/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import EventSource  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_15/extensions_v1beta1.py
+++ b/kuber/v1_15/extensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import Container  # noqa: F401
 from kuber.v1_15.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401
@@ -3753,7 +3754,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -3774,19 +3775,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self
@@ -4924,12 +4927,12 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         If specified, the port on the given protocol.  This can
         either be a numerical or named port on a pod.  If this field
@@ -4937,8 +4940,10 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -4949,7 +4954,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:
@@ -7388,11 +7393,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -7409,8 +7414,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7430,7 +7437,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -7458,12 +7465,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -7478,8 +7485,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -7497,10 +7506,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -7514,8 +7523,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7532,7 +7543,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_15/meta_v1.py
+++ b/kuber/v1_15/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_15/networking_v1.py
+++ b/kuber/v1_15/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
@@ -750,19 +751,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -771,7 +774,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_15/networking_v1beta1.py
+++ b/kuber/v1_15/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
@@ -438,7 +439,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -459,19 +460,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_15/node_v1alpha1.py
+++ b/kuber/v1_15/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/node_v1beta1.py
+++ b/kuber/v1_15/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/policy_v1beta1.py
+++ b/kuber/v1_15/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_15/rbac_v1.py
+++ b/kuber/v1_15/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/rbac_v1alpha1.py
+++ b/kuber/v1_15/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/rbac_v1beta1.py
+++ b/kuber/v1_15/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_15/scheduling_v1.py
+++ b/kuber/v1_15/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/scheduling_v1alpha1.py
+++ b/kuber/v1_15/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/scheduling_v1beta1.py
+++ b/kuber/v1_15/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_15/settings_v1alpha1.py
+++ b/kuber/v1_15/settings_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.core_v1 import EnvFromSource  # noqa: F401
 from kuber.v1_15.core_v1 import EnvVar  # noqa: F401
 from kuber.v1_15.meta_v1 import LabelSelector  # noqa: F401

--- a/kuber/v1_15/storage_v1.py
+++ b/kuber/v1_15/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_15/storage_v1alpha1.py
+++ b/kuber/v1_15/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_15/storage_v1beta1.py
+++ b/kuber/v1_15/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_15.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_15.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_15.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_16/__init__.py
+++ b/kuber/v1_16/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="15",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="2adc8d7091e89b6e3ca8d048140618ec89b39369",
 )

--- a/kuber/v1_16/admissionregistration_v1.py
+++ b/kuber/v1_16/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/admissionregistration_v1beta1.py
+++ b/kuber/v1_16/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/apiextensions_v1.py
+++ b/kuber/v1_16/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/apiextensions_v1beta1.py
+++ b/kuber/v1_16/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/apimachinery_runtime.py
+++ b/kuber/v1_16/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_16/apimachinery_version.py
+++ b/kuber/v1_16/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_16/apiregistration_v1.py
+++ b/kuber/v1_16/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/apiregistration_v1beta1.py
+++ b/kuber/v1_16/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/apps_v1.py
+++ b/kuber/v1_16/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_16/apps_v1beta1.py
+++ b/kuber/v1_16/apps_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401
@@ -1926,12 +1927,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -1946,8 +1947,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -1965,10 +1968,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -1982,8 +1985,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -2000,7 +2005,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_16/apps_v1beta2.py
+++ b/kuber/v1_16/apps_v1beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401
@@ -4133,11 +4134,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4154,8 +4155,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4175,7 +4178,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4203,12 +4206,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4223,8 +4226,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4242,10 +4247,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4259,8 +4264,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4277,7 +4284,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_16/auditregistration_v1alpha1.py
+++ b/kuber/v1_16/auditregistration_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_16/authentication_v1.py
+++ b/kuber/v1_16/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/authentication_v1beta1.py
+++ b/kuber/v1_16/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/authorization_v1.py
+++ b/kuber/v1_16/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/authorization_v1beta1.py
+++ b/kuber/v1_16/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/autoscaling_v1.py
+++ b/kuber/v1_16/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/autoscaling_v2beta1.py
+++ b/kuber/v1_16/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
@@ -136,8 +137,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -196,7 +197,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -213,7 +214,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -250,8 +251,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -271,7 +272,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -288,7 +289,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1589,11 +1590,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1611,7 +1612,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1697,7 +1698,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -1733,8 +1734,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -1755,7 +1756,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -1772,7 +1773,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1881,7 +1882,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1946,7 +1947,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -1980,7 +1981,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2000,7 +2001,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2090,7 +2091,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2152,7 +2153,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2193,7 +2194,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2245,7 +2246,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_16/autoscaling_v2beta2.py
+++ b/kuber/v1_16/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
@@ -1584,9 +1585,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1627,7 +1628,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -1661,7 +1662,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -1694,8 +1695,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1736,7 +1737,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -1751,7 +1752,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_16/batch_v1.py
+++ b/kuber/v1_16/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_16/batch_v1beta1.py
+++ b/kuber/v1_16/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_16/batch_v2alpha1.py
+++ b/kuber/v1_16/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_16/certificates_v1beta1.py
+++ b/kuber/v1_16/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/coordination_v1.py
+++ b/kuber/v1_16/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/coordination_v1beta1.py
+++ b/kuber/v1_16/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/core_v1.py
+++ b/kuber/v1_16/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import MicroTime  # noqa: F401
@@ -5275,7 +5276,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5326,7 +5327,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -8871,7 +8872,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -8941,14 +8942,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -8957,7 +8960,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22477,7 +22480,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -22513,7 +22516,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -25952,7 +25955,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26048,7 +26051,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26061,8 +26064,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26078,7 +26083,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -27091,7 +27096,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -27112,14 +27117,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -27128,7 +27135,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_16/custom_v1.py
+++ b/kuber/v1_16/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_16/discovery_v1alpha1.py
+++ b/kuber/v1_16/discovery_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_16/events_v1beta1.py
+++ b/kuber/v1_16/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import EventSource  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_16/extensions_v1beta1.py
+++ b/kuber/v1_16/extensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import Container  # noqa: F401
 from kuber.v1_16.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401
@@ -3773,7 +3774,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -3794,19 +3795,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self
@@ -4944,12 +4947,12 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         If specified, the port on the given protocol.  This can
         either be a numerical or named port on a pod.  If this field
@@ -4957,8 +4960,10 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -4969,7 +4974,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:
@@ -7414,11 +7419,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -7435,8 +7440,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7456,7 +7463,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -7484,12 +7491,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -7504,8 +7511,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -7523,10 +7532,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -7540,8 +7549,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7558,7 +7569,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_16/meta_v1.py
+++ b/kuber/v1_16/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_16/networking_v1.py
+++ b/kuber/v1_16/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
@@ -750,19 +751,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -771,7 +774,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_16/networking_v1beta1.py
+++ b/kuber/v1_16/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
@@ -438,7 +439,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -459,19 +460,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_16/node_v1alpha1.py
+++ b/kuber/v1_16/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_16/node_v1beta1.py
+++ b/kuber/v1_16/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_16/policy_v1beta1.py
+++ b/kuber/v1_16/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_16/rbac_v1.py
+++ b/kuber/v1_16/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/rbac_v1alpha1.py
+++ b/kuber/v1_16/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/rbac_v1beta1.py
+++ b/kuber/v1_16/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_16/scheduling_v1.py
+++ b/kuber/v1_16/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_16/scheduling_v1alpha1.py
+++ b/kuber/v1_16/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_16/scheduling_v1beta1.py
+++ b/kuber/v1_16/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_16/settings_v1alpha1.py
+++ b/kuber/v1_16/settings_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.core_v1 import EnvFromSource  # noqa: F401
 from kuber.v1_16.core_v1 import EnvVar  # noqa: F401
 from kuber.v1_16.meta_v1 import LabelSelector  # noqa: F401

--- a/kuber/v1_16/storage_v1.py
+++ b/kuber/v1_16/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_16/storage_v1alpha1.py
+++ b/kuber/v1_16/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_16/storage_v1beta1.py
+++ b/kuber/v1_16/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_16.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_16.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_16.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_17/__init__.py
+++ b/kuber/v1_17/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="16",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="d88fadbd65c5e8bde22630d251766a634c7613b0",
 )

--- a/kuber/v1_17/admissionregistration_v1.py
+++ b/kuber/v1_17/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/admissionregistration_v1beta1.py
+++ b/kuber/v1_17/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/apiextensions_v1.py
+++ b/kuber/v1_17/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/apiextensions_v1beta1.py
+++ b/kuber/v1_17/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/apimachinery_runtime.py
+++ b/kuber/v1_17/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_17/apimachinery_version.py
+++ b/kuber/v1_17/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_17/apiregistration_v1.py
+++ b/kuber/v1_17/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/apiregistration_v1beta1.py
+++ b/kuber/v1_17/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/apps_v1.py
+++ b/kuber/v1_17/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_17/apps_v1beta1.py
+++ b/kuber/v1_17/apps_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401
@@ -1926,12 +1927,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -1946,8 +1947,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -1965,10 +1968,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -1982,8 +1985,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -2000,7 +2005,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_17/apps_v1beta2.py
+++ b/kuber/v1_17/apps_v1beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401
@@ -4133,11 +4134,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4154,8 +4155,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4175,7 +4178,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4203,12 +4206,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4223,8 +4226,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4242,10 +4247,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4259,8 +4264,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4277,7 +4284,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_17/auditregistration_v1alpha1.py
+++ b/kuber/v1_17/auditregistration_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_17/authentication_v1.py
+++ b/kuber/v1_17/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/authentication_v1beta1.py
+++ b/kuber/v1_17/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/authorization_v1.py
+++ b/kuber/v1_17/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/authorization_v1beta1.py
+++ b/kuber/v1_17/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/autoscaling_v1.py
+++ b/kuber/v1_17/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/autoscaling_v2beta1.py
+++ b/kuber/v1_17/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
@@ -136,8 +137,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -196,7 +197,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -213,7 +214,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -250,8 +251,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -271,7 +272,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -288,7 +289,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1589,11 +1590,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1611,7 +1612,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1697,7 +1698,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -1733,8 +1734,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -1755,7 +1756,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -1772,7 +1773,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1881,7 +1882,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1946,7 +1947,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -1980,7 +1981,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2000,7 +2001,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2090,7 +2091,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2152,7 +2153,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2193,7 +2194,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2245,7 +2246,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_17/autoscaling_v2beta2.py
+++ b/kuber/v1_17/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
@@ -1584,9 +1585,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1627,7 +1628,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -1661,7 +1662,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -1694,8 +1695,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1736,7 +1737,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -1751,7 +1752,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_17/batch_v1.py
+++ b/kuber/v1_17/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_17/batch_v1beta1.py
+++ b/kuber/v1_17/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_17/batch_v2alpha1.py
+++ b/kuber/v1_17/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_17/certificates_v1beta1.py
+++ b/kuber/v1_17/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/coordination_v1.py
+++ b/kuber/v1_17/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/coordination_v1beta1.py
+++ b/kuber/v1_17/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/core_v1.py
+++ b/kuber/v1_17/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import MicroTime  # noqa: F401
@@ -5275,7 +5276,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5326,7 +5327,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -8871,7 +8872,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -8941,14 +8942,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -8957,7 +8960,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22473,7 +22476,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -22509,7 +22512,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -25948,7 +25951,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26044,7 +26047,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26057,8 +26060,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26074,7 +26079,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -27133,7 +27138,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -27154,14 +27159,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -27170,7 +27177,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_17/custom_v1.py
+++ b/kuber/v1_17/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/discovery_v1beta1.py
+++ b/kuber/v1_17/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_17/events_v1beta1.py
+++ b/kuber/v1_17/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import EventSource  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_17/extensions_v1beta1.py
+++ b/kuber/v1_17/extensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import Container  # noqa: F401
 from kuber.v1_17.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401
@@ -3773,7 +3774,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -3794,19 +3795,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self
@@ -4944,12 +4947,12 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         If specified, the port on the given protocol.  This can
         either be a numerical or named port on a pod.  If this field
@@ -4957,8 +4960,10 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -4969,7 +4974,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         present, only traffic on the specified protocol AND port
         will be matched.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:
@@ -7414,11 +7419,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -7435,8 +7440,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7456,7 +7463,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -7484,12 +7491,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -7504,8 +7511,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -7523,10 +7532,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -7540,8 +7549,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -7558,7 +7569,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_17/flowcontrol_v1alpha1.py
+++ b/kuber/v1_17/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_17/meta_v1.py
+++ b/kuber/v1_17/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_17/networking_v1.py
+++ b/kuber/v1_17/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
@@ -750,19 +751,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -771,7 +774,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_17/networking_v1beta1.py
+++ b/kuber/v1_17/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
@@ -438,7 +439,7 @@ class IngressBackend(_kuber_definitions.Definition):
         }
         self._types = {
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -459,19 +460,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_17/node_v1alpha1.py
+++ b/kuber/v1_17/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_17/node_v1beta1.py
+++ b/kuber/v1_17/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_17/policy_v1beta1.py
+++ b/kuber/v1_17/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_17/rbac_v1.py
+++ b/kuber/v1_17/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/rbac_v1alpha1.py
+++ b/kuber/v1_17/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/rbac_v1beta1.py
+++ b/kuber/v1_17/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_17/scheduling_v1.py
+++ b/kuber/v1_17/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_17/scheduling_v1alpha1.py
+++ b/kuber/v1_17/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_17/scheduling_v1beta1.py
+++ b/kuber/v1_17/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_17/settings_v1alpha1.py
+++ b/kuber/v1_17/settings_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.core_v1 import EnvFromSource  # noqa: F401
 from kuber.v1_17.core_v1 import EnvVar  # noqa: F401
 from kuber.v1_17.meta_v1 import LabelSelector  # noqa: F401

--- a/kuber/v1_17/storage_v1.py
+++ b/kuber/v1_17/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_17/storage_v1alpha1.py
+++ b/kuber/v1_17/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_17/storage_v1beta1.py
+++ b/kuber/v1_17/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_17.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_17.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_17.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_18/__init__.py
+++ b/kuber/v1_18/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="14",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="89182bdd065fbcaffefec691908a739d161efc03",
 )

--- a/kuber/v1_18/admissionregistration_v1.py
+++ b/kuber/v1_18/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/admissionregistration_v1beta1.py
+++ b/kuber/v1_18/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/apiextensions_v1.py
+++ b/kuber/v1_18/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/apiextensions_v1beta1.py
+++ b/kuber/v1_18/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/apimachinery_runtime.py
+++ b/kuber/v1_18/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_18/apimachinery_version.py
+++ b/kuber/v1_18/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_18/apiregistration_v1.py
+++ b/kuber/v1_18/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/apiregistration_v1beta1.py
+++ b/kuber/v1_18/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/apps_v1.py
+++ b/kuber/v1_18/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import Container  # noqa: F401
 from kuber.v1_18.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_18.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_18/auditregistration_v1alpha1.py
+++ b/kuber/v1_18/auditregistration_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_18/authentication_v1.py
+++ b/kuber/v1_18/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/authentication_v1beta1.py
+++ b/kuber/v1_18/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/authorization_v1.py
+++ b/kuber/v1_18/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/authorization_v1beta1.py
+++ b/kuber/v1_18/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/autoscaling_v1.py
+++ b/kuber/v1_18/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/autoscaling_v2beta1.py
+++ b/kuber/v1_18/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
@@ -136,8 +137,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -196,7 +197,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -213,7 +214,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -250,8 +251,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -271,7 +272,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -288,7 +289,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1589,11 +1590,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1611,7 +1612,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1697,7 +1698,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -1733,8 +1734,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -1755,7 +1756,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -1772,7 +1773,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1881,7 +1882,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1946,7 +1947,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -1980,7 +1981,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2000,7 +2001,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2090,7 +2091,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2152,7 +2153,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2193,7 +2194,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2245,7 +2246,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_18/autoscaling_v2beta2.py
+++ b/kuber/v1_18/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
@@ -1920,9 +1921,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -1997,7 +1998,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2030,8 +2031,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2072,7 +2073,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2087,7 +2088,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_18/batch_v1.py
+++ b/kuber/v1_18/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import Container  # noqa: F401
 from kuber.v1_18.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_18.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_18/batch_v1beta1.py
+++ b/kuber/v1_18/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import Container  # noqa: F401
 from kuber.v1_18.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_18.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_18/batch_v2alpha1.py
+++ b/kuber/v1_18/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import Container  # noqa: F401
 from kuber.v1_18.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_18.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_18/certificates_v1beta1.py
+++ b/kuber/v1_18/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/coordination_v1.py
+++ b/kuber/v1_18/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/coordination_v1beta1.py
+++ b/kuber/v1_18/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/core_v1.py
+++ b/kuber/v1_18/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import MicroTime  # noqa: F401
@@ -5303,7 +5304,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5354,7 +5355,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -8931,7 +8932,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9001,14 +9002,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9017,7 +9020,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22575,7 +22578,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -22611,7 +22614,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26081,7 +26084,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26206,7 +26209,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26219,8 +26222,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26236,7 +26241,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -27295,7 +27300,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -27316,14 +27321,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -27332,7 +27339,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_18/custom_v1.py
+++ b/kuber/v1_18/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/discovery_v1beta1.py
+++ b/kuber/v1_18/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_18/events_v1beta1.py
+++ b/kuber/v1_18/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import EventSource  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_18/extensions_v1beta1.py
+++ b/kuber/v1_18/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_18/flowcontrol_v1alpha1.py
+++ b/kuber/v1_18/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_18/meta_v1.py
+++ b/kuber/v1_18/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_18/networking_v1.py
+++ b/kuber/v1_18/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
@@ -751,19 +752,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -772,7 +775,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_18/networking_v1beta1.py
+++ b/kuber/v1_18/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_18/node_v1alpha1.py
+++ b/kuber/v1_18/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_18/node_v1beta1.py
+++ b/kuber/v1_18/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_18/policy_v1beta1.py
+++ b/kuber/v1_18/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_18/rbac_v1.py
+++ b/kuber/v1_18/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/rbac_v1alpha1.py
+++ b/kuber/v1_18/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/rbac_v1beta1.py
+++ b/kuber/v1_18/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_18/scheduling_v1.py
+++ b/kuber/v1_18/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_18/scheduling_v1alpha1.py
+++ b/kuber/v1_18/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_18/scheduling_v1beta1.py
+++ b/kuber/v1_18/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_18/settings_v1alpha1.py
+++ b/kuber/v1_18/settings_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.core_v1 import EnvFromSource  # noqa: F401
 from kuber.v1_18.core_v1 import EnvVar  # noqa: F401
 from kuber.v1_18.meta_v1 import LabelSelector  # noqa: F401

--- a/kuber/v1_18/storage_v1.py
+++ b/kuber/v1_18/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_18/storage_v1alpha1.py
+++ b/kuber/v1_18/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_18/storage_v1beta1.py
+++ b/kuber/v1_18/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_18.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_18.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_18.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_19/__init__.py
+++ b/kuber/v1_19/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="6",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="fbf646b339dc52336b55d8ec85c181981b86331a",
 )

--- a/kuber/v1_19/admissionregistration_v1.py
+++ b/kuber/v1_19/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/admissionregistration_v1beta1.py
+++ b/kuber/v1_19/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/apiextensions_v1.py
+++ b/kuber/v1_19/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/apiextensions_v1beta1.py
+++ b/kuber/v1_19/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/apimachinery_runtime.py
+++ b/kuber/v1_19/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_19/apimachinery_version.py
+++ b/kuber/v1_19/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_19/apiregistration_v1.py
+++ b/kuber/v1_19/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/apiregistration_v1beta1.py
+++ b/kuber/v1_19/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/apps_v1.py
+++ b/kuber/v1_19/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import Container  # noqa: F401
 from kuber.v1_19.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_19.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_19/authentication_v1.py
+++ b/kuber/v1_19/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/authentication_v1beta1.py
+++ b/kuber/v1_19/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/authorization_v1.py
+++ b/kuber/v1_19/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/authorization_v1beta1.py
+++ b/kuber/v1_19/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/autoscaling_v1.py
+++ b/kuber/v1_19/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/autoscaling_v2beta1.py
+++ b/kuber/v1_19/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
@@ -136,8 +137,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -196,7 +197,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -213,7 +214,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -250,8 +251,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -271,7 +272,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -288,7 +289,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1589,11 +1590,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1611,7 +1612,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1697,7 +1698,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -1733,8 +1734,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -1755,7 +1756,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -1772,7 +1773,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1881,7 +1882,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1946,7 +1947,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -1980,7 +1981,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2000,7 +2001,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2090,7 +2091,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2152,7 +2153,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2193,7 +2194,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2245,7 +2246,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_19/autoscaling_v2beta2.py
+++ b/kuber/v1_19/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
@@ -1920,9 +1921,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -1997,7 +1998,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2030,8 +2031,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2072,7 +2073,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2087,7 +2088,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_19/batch_v1.py
+++ b/kuber/v1_19/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import Container  # noqa: F401
 from kuber.v1_19.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_19.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_19/batch_v1beta1.py
+++ b/kuber/v1_19/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import Container  # noqa: F401
 from kuber.v1_19.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_19.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_19/batch_v2alpha1.py
+++ b/kuber/v1_19/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import Container  # noqa: F401
 from kuber.v1_19.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_19.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_19/certificates_v1.py
+++ b/kuber/v1_19/certificates_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/certificates_v1beta1.py
+++ b/kuber/v1_19/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/coordination_v1.py
+++ b/kuber/v1_19/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/coordination_v1beta1.py
+++ b/kuber/v1_19/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/core_v1.py
+++ b/kuber/v1_19/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import MicroTime  # noqa: F401
@@ -5323,7 +5324,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5374,7 +5375,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -9051,7 +9052,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9121,14 +9122,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9137,7 +9140,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22846,7 +22849,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -22882,7 +22885,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26476,7 +26479,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26603,7 +26606,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26616,8 +26619,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26633,7 +26638,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -27716,7 +27721,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -27737,14 +27742,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -27753,7 +27760,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_19/custom_v1.py
+++ b/kuber/v1_19/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/discovery_v1beta1.py
+++ b/kuber/v1_19/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_19/events_v1.py
+++ b/kuber/v1_19/events_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import EventSource  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_19/events_v1beta1.py
+++ b/kuber/v1_19/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import EventSource  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_19/extensions_v1beta1.py
+++ b/kuber/v1_19/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_19/flowcontrol_v1alpha1.py
+++ b/kuber/v1_19/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_19/meta_v1.py
+++ b/kuber/v1_19/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_19/networking_v1.py
+++ b/kuber/v1_19/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.core_v1 import LoadBalancerStatus  # noqa: F401
@@ -2286,19 +2287,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -2307,7 +2310,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_19/networking_v1beta1.py
+++ b/kuber/v1_19/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_19/node_v1alpha1.py
+++ b/kuber/v1_19/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_19/node_v1beta1.py
+++ b/kuber/v1_19/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_19/policy_v1beta1.py
+++ b/kuber/v1_19/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_19/rbac_v1.py
+++ b/kuber/v1_19/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/rbac_v1alpha1.py
+++ b/kuber/v1_19/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/rbac_v1beta1.py
+++ b/kuber/v1_19/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_19/scheduling_v1.py
+++ b/kuber/v1_19/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_19/scheduling_v1alpha1.py
+++ b/kuber/v1_19/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_19/scheduling_v1beta1.py
+++ b/kuber/v1_19/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_19/settings_v1alpha1.py
+++ b/kuber/v1_19/settings_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.core_v1 import EnvFromSource  # noqa: F401
 from kuber.v1_19.core_v1 import EnvVar  # noqa: F401
 from kuber.v1_19.meta_v1 import LabelSelector  # noqa: F401

--- a/kuber/v1_19/storage_v1.py
+++ b/kuber/v1_19/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_19/storage_v1alpha1.py
+++ b/kuber/v1_19/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_19/storage_v1beta1.py
+++ b/kuber/v1_19/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_19.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_19.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_19.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_20/__init__.py
+++ b/kuber/v1_20/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="1",
     pre_release="",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="c4d752765b3bbac2237bf87cf0b1c2e307844666",
 )

--- a/kuber/v1_20/admissionregistration_v1.py
+++ b/kuber/v1_20/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/admissionregistration_v1beta1.py
+++ b/kuber/v1_20/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/apiextensions_v1.py
+++ b/kuber/v1_20/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/apiextensions_v1beta1.py
+++ b/kuber/v1_20/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/apimachinery_runtime.py
+++ b/kuber/v1_20/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_20/apimachinery_version.py
+++ b/kuber/v1_20/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_20/apiregistration_v1.py
+++ b/kuber/v1_20/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/apiregistration_v1beta1.py
+++ b/kuber/v1_20/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/apiserverinternal_v1alpha1.py
+++ b/kuber/v1_20/apiserverinternal_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/apps_v1.py
+++ b/kuber/v1_20/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import Container  # noqa: F401
 from kuber.v1_20.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_20.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_20/authentication_v1.py
+++ b/kuber/v1_20/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/authentication_v1beta1.py
+++ b/kuber/v1_20/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/authorization_v1.py
+++ b/kuber/v1_20/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/authorization_v1beta1.py
+++ b/kuber/v1_20/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/autoscaling_v1.py
+++ b/kuber/v1_20/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/autoscaling_v2beta1.py
+++ b/kuber/v1_20/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
@@ -50,7 +51,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
             "container": (str, None),
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -131,7 +132,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ContainerResourceMetricSource":
         return self
@@ -175,7 +176,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         self._types = {
             "container": (str, None),
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -246,7 +247,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:
@@ -396,8 +397,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -456,7 +457,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -473,7 +474,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -510,8 +511,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -531,7 +532,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -548,7 +549,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1941,11 +1942,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2049,7 +2050,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -2085,8 +2086,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -2107,7 +2108,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -2124,7 +2125,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2233,7 +2234,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2298,7 +2299,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -2332,7 +2333,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2352,7 +2353,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2442,7 +2443,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2504,7 +2505,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2545,7 +2546,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2597,7 +2598,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_20/autoscaling_v2beta2.py
+++ b/kuber/v1_20/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
@@ -2208,9 +2209,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2251,7 +2252,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -2285,7 +2286,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2318,8 +2319,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2360,7 +2361,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2375,7 +2376,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_20/batch_v1.py
+++ b/kuber/v1_20/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import Container  # noqa: F401
 from kuber.v1_20.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_20.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_20/batch_v1beta1.py
+++ b/kuber/v1_20/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import Container  # noqa: F401
 from kuber.v1_20.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_20.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_20/batch_v2alpha1.py
+++ b/kuber/v1_20/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import Container  # noqa: F401
 from kuber.v1_20.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_20.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_20/certificates_v1.py
+++ b/kuber/v1_20/certificates_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/certificates_v1beta1.py
+++ b/kuber/v1_20/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/coordination_v1.py
+++ b/kuber/v1_20/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/coordination_v1beta1.py
+++ b/kuber/v1_20/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/core_v1.py
+++ b/kuber/v1_20/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import Condition  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
@@ -5322,7 +5323,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5373,7 +5374,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -9056,7 +9057,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9126,14 +9127,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9142,7 +9145,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22971,7 +22974,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -23007,7 +23010,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26601,7 +26604,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26734,7 +26737,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26747,8 +26750,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26764,7 +26769,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -28071,7 +28076,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -28092,14 +28097,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -28108,7 +28115,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_20/custom_v1.py
+++ b/kuber/v1_20/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/discovery_v1beta1.py
+++ b/kuber/v1_20/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_20/events_v1.py
+++ b/kuber/v1_20/events_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import EventSource  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_20/events_v1beta1.py
+++ b/kuber/v1_20/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.core_v1 import EventSource  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_20/extensions_v1beta1.py
+++ b/kuber/v1_20/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_20/flowcontrol_v1alpha1.py
+++ b/kuber/v1_20/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/flowcontrol_v1beta1.py
+++ b/kuber/v1_20/flowcontrol_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_20/meta_v1.py
+++ b/kuber/v1_20/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_20/networking_v1.py
+++ b/kuber/v1_20/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.core_v1 import LoadBalancerStatus  # noqa: F401
@@ -2286,19 +2287,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -2307,7 +2310,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_20/networking_v1beta1.py
+++ b/kuber/v1_20/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_20/node_v1.py
+++ b/kuber/v1_20/node_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_20/node_v1alpha1.py
+++ b/kuber/v1_20/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_20/node_v1beta1.py
+++ b/kuber/v1_20/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_20/policy_v1beta1.py
+++ b/kuber/v1_20/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_20/rbac_v1.py
+++ b/kuber/v1_20/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/rbac_v1alpha1.py
+++ b/kuber/v1_20/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/rbac_v1beta1.py
+++ b/kuber/v1_20/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_20/scheduling_v1.py
+++ b/kuber/v1_20/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_20/scheduling_v1alpha1.py
+++ b/kuber/v1_20/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_20/scheduling_v1beta1.py
+++ b/kuber/v1_20/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_20/storage_v1.py
+++ b/kuber/v1_20/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_20/storage_v1alpha1.py
+++ b/kuber/v1_20/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_20/storage_v1beta1.py
+++ b/kuber/v1_20/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_20.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_20.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_20.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_21/__init__.py
+++ b/kuber/v1_21/__init__.py
@@ -13,6 +13,6 @@ KUBERNETES_VERSION = _versioning.KubernetesVersion(
     patch="0",
     pre_release="alpha.0",
     build="",
-    created_at=_datetime.datetime(2020, 12, 31),
+    created_at=_datetime.datetime(2021, 1, 7),
     commit_sha="98bc258bf5516b6c60860e06845b899eab29825d",
 )

--- a/kuber/v1_21/admissionregistration_v1.py
+++ b/kuber/v1_21/admissionregistration_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/admissionregistration_v1beta1.py
+++ b/kuber/v1_21/admissionregistration_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/apiextensions_v1.py
+++ b/kuber/v1_21/apiextensions_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/apiextensions_v1beta1.py
+++ b/kuber/v1_21/apiextensions_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/apimachinery_runtime.py
+++ b/kuber/v1_21/apimachinery_runtime.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class RawExtension(_kuber_definitions.Definition):

--- a/kuber/v1_21/apimachinery_version.py
+++ b/kuber/v1_21/apimachinery_version.py
@@ -3,6 +3,7 @@ import typing  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 
 
 class Info(_kuber_definitions.Definition):

--- a/kuber/v1_21/apiregistration_v1.py
+++ b/kuber/v1_21/apiregistration_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/apiregistration_v1beta1.py
+++ b/kuber/v1_21/apiregistration_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/apiserverinternal_v1alpha1.py
+++ b/kuber/v1_21/apiserverinternal_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/apps_v1.py
+++ b/kuber/v1_21/apps_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import Container  # noqa: F401
 from kuber.v1_21.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_21.core_v1 import EnvFromSource  # noqa: F401
@@ -4119,11 +4120,11 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxUnavailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of DaemonSet pods that can be unavailable
         during the update. Value can be an absolute number (ex: 5)
@@ -4140,8 +4141,10 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4161,7 +4164,7 @@ class RollingUpdateDaemonSet(_kuber_definitions.Definition):
         pods, thus ensuring that at least 70% of original number of
         DaemonSet pods are available at all times during the update.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDaemonSet":
         return self
@@ -4189,12 +4192,12 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
             "maxUnavailable": max_unavailable if max_unavailable is not None else None,
         }
         self._types = {
-            "maxSurge": (int, None),
-            "maxUnavailable": (int, None),
+            "maxSurge": (_types.integer_or_string, None),
+            "maxUnavailable": (_types.integer_or_string, None),
         }
 
     @property
-    def max_surge(self) -> typing.Optional[int]:
+    def max_surge(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be scheduled above the
         desired number of pods. Value can be an absolute number (ex:
@@ -4209,8 +4212,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        value = self._properties.get("maxSurge")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxSurge"),
+        )
 
     @max_surge.setter
     def max_surge(self, value: typing.Union[str, int, None]):
@@ -4228,10 +4233,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         running at any time during the update is at most 130% of
         desired pods.
         """
-        self._properties["maxSurge"] = None if value is None else f"{value}"
+        self._properties["maxSurge"] = _types.integer_or_string(value)
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         The maximum number of pods that can be unavailable during
         the update. Value can be an absolute number (ex: 5) or a
@@ -4245,8 +4250,10 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -4263,7 +4270,7 @@ class RollingUpdateDeployment(_kuber_definitions.Definition):
         that the total number of pods available at all times during
         the update is at least 70% of desired pods.
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "RollingUpdateDeployment":
         return self

--- a/kuber/v1_21/authentication_v1.py
+++ b/kuber/v1_21/authentication_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/authentication_v1beta1.py
+++ b/kuber/v1_21/authentication_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/authorization_v1.py
+++ b/kuber/v1_21/authorization_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/authorization_v1beta1.py
+++ b/kuber/v1_21/authorization_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/autoscaling_v1.py
+++ b/kuber/v1_21/autoscaling_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/autoscaling_v2beta1.py
+++ b/kuber/v1_21/autoscaling_v2beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
@@ -50,7 +51,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
             "container": (str, None),
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -131,7 +132,7 @@ class ContainerResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ContainerResourceMetricSource":
         return self
@@ -175,7 +176,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         self._types = {
             "container": (str, None),
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -246,7 +247,7 @@ class ContainerResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:
@@ -396,8 +397,8 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
-            "targetValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -456,7 +457,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target per-pod value of global
         metric (as a quantity). Mutually exclusive with TargetValue.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     @property
     def target_value(self) -> typing.Optional[str]:
@@ -473,7 +474,7 @@ class ExternalMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity). Mutually exclusive with TargetAverageValue.
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ExternalMetricSource":
         return self
@@ -510,8 +511,8 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
             else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
-            "currentValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "metricSelector": (LabelSelector, None),
         }
@@ -531,7 +532,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of metric averaged
         over autoscaled pods.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -548,7 +549,7 @@ class ExternalMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity)
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -1941,11 +1942,11 @@ class ObjectMetricSource(_kuber_definitions.Definition):
             "targetValue": target_value if target_value is not None else None,
         }
         self._types = {
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
-            "targetValue": (str, None),
+            "targetValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -1963,7 +1964,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2049,7 +2050,7 @@ class ObjectMetricSource(_kuber_definitions.Definition):
         targetValue is the target value of the metric (as a
         quantity).
         """
-        self._properties["targetValue"] = None if value is None else f"{value}"
+        self._properties["targetValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ObjectMetricSource":
         return self
@@ -2085,8 +2086,8 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
             "target": target if target is not None else CrossVersionObjectReference(),
         }
         self._types = {
-            "averageValue": (str, None),
-            "currentValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "currentValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
             "target": (CrossVersionObjectReference, None),
@@ -2107,7 +2108,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def current_value(self) -> typing.Optional[str]:
@@ -2124,7 +2125,7 @@ class ObjectMetricStatus(_kuber_definitions.Definition):
         currentValue is the current value of the metric (as a
         quantity).
         """
-        self._properties["currentValue"] = None if value is None else f"{value}"
+        self._properties["currentValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2233,7 +2234,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         self._types = {
             "metricName": (str, None),
             "selector": (LabelSelector, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2298,7 +2299,7 @@ class PodsMetricSource(_kuber_definitions.Definition):
         targetAverageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "PodsMetricSource":
         return self
@@ -2332,7 +2333,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "metricName": (str, None),
             "selector": (LabelSelector, None),
         }
@@ -2352,7 +2353,7 @@ class PodsMetricStatus(_kuber_definitions.Definition):
         currentAverageValue is the current value of the average of
         the metric across all relevant pods (as a quantity)
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def metric_name(self) -> str:
@@ -2442,7 +2443,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         self._types = {
             "name": (str, None),
             "targetAverageUtilization": (int, None),
-            "targetAverageValue": (str, None),
+            "targetAverageValue": (_types.integer_or_string, None),
         }
 
     @property
@@ -2504,7 +2505,7 @@ class ResourceMetricSource(_kuber_definitions.Definition):
         (instead of as a percentage of the request), similar to the
         "pods" metric source type.
         """
-        self._properties["targetAverageValue"] = None if value is None else f"{value}"
+        self._properties["targetAverageValue"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ResourceMetricSource":
         return self
@@ -2545,7 +2546,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "currentAverageUtilization": (int, None),
-            "currentAverageValue": (str, None),
+            "currentAverageValue": (_types.integer_or_string, None),
             "name": (str, None),
         }
 
@@ -2597,7 +2598,7 @@ class ResourceMetricStatus(_kuber_definitions.Definition):
         "pods" metric source type. It will always be set, regardless
         of the corresponding metric specification.
         """
-        self._properties["currentAverageValue"] = None if value is None else f"{value}"
+        self._properties["currentAverageValue"] = _types.integer_or_string(value)
 
     @property
     def name(self) -> str:

--- a/kuber/v1_21/autoscaling_v2beta2.py
+++ b/kuber/v1_21/autoscaling_v2beta2.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
@@ -2208,9 +2209,9 @@ class MetricTarget(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
+            "averageValue": (_types.integer_or_string, None),
             "type": (str, None),
-            "value": (str, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2251,7 +2252,7 @@ class MetricTarget(_kuber_definitions.Definition):
         averageValue is the target value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def type_(self) -> str:
@@ -2285,7 +2286,7 @@ class MetricTarget(_kuber_definitions.Definition):
         """
         value is the target value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricTarget":
         return self
@@ -2318,8 +2319,8 @@ class MetricValueStatus(_kuber_definitions.Definition):
         }
         self._types = {
             "averageUtilization": (int, None),
-            "averageValue": (str, None),
-            "value": (str, None),
+            "averageValue": (_types.integer_or_string, None),
+            "value": (_types.integer_or_string, None),
         }
 
     @property
@@ -2360,7 +2361,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         averageValue is the current value of the average of the
         metric across all relevant pods (as a quantity)
         """
-        self._properties["averageValue"] = None if value is None else f"{value}"
+        self._properties["averageValue"] = _types.integer_or_string(value)
 
     @property
     def value(self) -> typing.Optional[str]:
@@ -2375,7 +2376,7 @@ class MetricValueStatus(_kuber_definitions.Definition):
         """
         value is the current value of the metric (as a quantity).
         """
-        self._properties["value"] = None if value is None else f"{value}"
+        self._properties["value"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "MetricValueStatus":
         return self

--- a/kuber/v1_21/batch_v1.py
+++ b/kuber/v1_21/batch_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import Container  # noqa: F401
 from kuber.v1_21.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_21.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_21/batch_v1beta1.py
+++ b/kuber/v1_21/batch_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import Container  # noqa: F401
 from kuber.v1_21.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_21.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_21/batch_v2alpha1.py
+++ b/kuber/v1_21/batch_v2alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import Container  # noqa: F401
 from kuber.v1_21.core_v1 import ContainerPort  # noqa: F401
 from kuber.v1_21.core_v1 import EnvFromSource  # noqa: F401

--- a/kuber/v1_21/certificates_v1.py
+++ b/kuber/v1_21/certificates_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/certificates_v1beta1.py
+++ b/kuber/v1_21/certificates_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/coordination_v1.py
+++ b/kuber/v1_21/coordination_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/coordination_v1beta1.py
+++ b/kuber/v1_21/coordination_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import MicroTime  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/core_v1.py
+++ b/kuber/v1_21/core_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import Condition  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
@@ -5322,7 +5323,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         }
         self._types = {
             "medium": (str, None),
-            "sizeLimit": (str, None),
+            "sizeLimit": (_types.integer_or_string, None),
         }
 
     @property
@@ -5373,7 +5374,7 @@ class EmptyDirVolumeSource(_kuber_definitions.Definition):
         is nil which means that the limit is undefined. More info:
         http://kubernetes.io/docs/user-guide/volumes#emptydir
         """
-        self._properties["sizeLimit"] = None if value is None else f"{value}"
+        self._properties["sizeLimit"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "EmptyDirVolumeSource":
         return self
@@ -9056,7 +9057,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
             "host": (str, None),
             "httpHeaders": (list, HTTPHeader),
             "path": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "scheme": (str, None),
         }
 
@@ -9126,14 +9127,16 @@ class HTTPGetAction(_kuber_definitions.Definition):
         self._properties["path"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Name or number of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -9142,7 +9145,7 @@ class HTTPGetAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def scheme(self) -> str:
@@ -22971,7 +22974,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         }
         self._types = {
             "containerName": (str, None),
-            "divisor": (str, None),
+            "divisor": (_types.integer_or_string, None),
             "resource": (str, None),
         }
 
@@ -23007,7 +23010,7 @@ class ResourceFieldSelector(_kuber_definitions.Definition):
         Specifies the output format of the exposed resources,
         defaults to "1"
         """
-        self._properties["divisor"] = None if value is None else f"{value}"
+        self._properties["divisor"] = _types.integer_or_string(value)
 
     @property
     def resource(self) -> str:
@@ -26601,7 +26604,7 @@ class ServicePort(_kuber_definitions.Definition):
             "nodePort": (int, None),
             "port": (int, None),
             "protocol": (str, None),
-            "targetPort": (int, None),
+            "targetPort": (_types.integer_or_string, None),
         }
 
     @property
@@ -26734,7 +26737,7 @@ class ServicePort(_kuber_definitions.Definition):
         self._properties["protocol"] = value
 
     @property
-    def target_port(self) -> typing.Optional[int]:
+    def target_port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the pods targeted by
         the service. Number must be in the range 1 to 65535. Name
@@ -26747,8 +26750,10 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        value = self._properties.get("targetPort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("targetPort"),
+        )
 
     @target_port.setter
     def target_port(self, value: typing.Union[str, int, None]):
@@ -26764,7 +26769,7 @@ class ServicePort(_kuber_definitions.Definition):
         https://kubernetes.io/docs/concepts/services-
         networking/service/#defining-a-service
         """
-        self._properties["targetPort"] = None if value is None else f"{value}"
+        self._properties["targetPort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "ServicePort":
         return self
@@ -28071,7 +28076,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         }
         self._types = {
             "host": (str, None),
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
         }
 
     @property
@@ -28092,14 +28097,16 @@ class TCPSocketAction(_kuber_definitions.Definition):
         self._properties["host"] = value
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         Number or name of the port to access on the container.
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -28108,7 +28115,7 @@ class TCPSocketAction(_kuber_definitions.Definition):
         Number must be in the range 1 to 65535. Name must be an
         IANA_SVC_NAME.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "TCPSocketAction":
         return self

--- a/kuber/v1_21/custom_v1.py
+++ b/kuber/v1_21/custom_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/discovery_v1beta1.py
+++ b/kuber/v1_21/discovery_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import ObjectReference  # noqa: F401

--- a/kuber/v1_21/events_v1.py
+++ b/kuber/v1_21/events_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import EventSource  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_21/events_v1beta1.py
+++ b/kuber/v1_21/events_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.core_v1 import EventSource  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import MicroTime  # noqa: F401

--- a/kuber/v1_21/extensions_v1beta1.py
+++ b/kuber/v1_21/extensions_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
@@ -504,7 +505,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -553,19 +554,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_21/flowcontrol_v1alpha1.py
+++ b/kuber/v1_21/flowcontrol_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/flowcontrol_v1beta1.py
+++ b/kuber/v1_21/flowcontrol_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import Status  # noqa: F401

--- a/kuber/v1_21/meta_v1.py
+++ b/kuber/v1_21/meta_v1.py
@@ -4,6 +4,7 @@ import datetime as _datetime  # noqa: F401
 from kubernetes import client  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.apimachinery_runtime import RawExtension  # noqa: F401
 
 

--- a/kuber/v1_21/networking_v1.py
+++ b/kuber/v1_21/networking_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.core_v1 import LoadBalancerStatus  # noqa: F401
@@ -2286,19 +2287,21 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
             "protocol": protocol if protocol is not None else "",
         }
         self._types = {
-            "port": (int, None),
+            "port": (_types.integer_or_string, None),
             "protocol": (str, None),
         }
 
     @property
-    def port(self) -> typing.Optional[int]:
+    def port(self) -> typing.Union[str, int, None]:
         """
         The port on the given protocol. This can either be a
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        value = self._properties.get("port")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("port"),
+        )
 
     @port.setter
     def port(self, value: typing.Union[str, int, None]):
@@ -2307,7 +2310,7 @@ class NetworkPolicyPort(_kuber_definitions.Definition):
         numerical or named port on a pod. If this field is not
         provided, this matches all port names and numbers.
         """
-        self._properties["port"] = None if value is None else f"{value}"
+        self._properties["port"] = _types.integer_or_string(value)
 
     @property
     def protocol(self) -> str:

--- a/kuber/v1_21/networking_v1beta1.py
+++ b/kuber/v1_21/networking_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.core_v1 import LoadBalancerStatus  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
@@ -501,7 +502,7 @@ class IngressBackend(_kuber_definitions.Definition):
         self._types = {
             "resource": (TypedLocalObjectReference, None),
             "serviceName": (str, None),
-            "servicePort": (int, None),
+            "servicePort": (_types.integer_or_string, None),
         }
 
     @property
@@ -550,19 +551,21 @@ class IngressBackend(_kuber_definitions.Definition):
         self._properties["serviceName"] = value
 
     @property
-    def service_port(self) -> typing.Optional[int]:
+    def service_port(self) -> typing.Union[str, int, None]:
         """
         Specifies the port of the referenced service.
         """
-        value = self._properties.get("servicePort")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("servicePort"),
+        )
 
     @service_port.setter
     def service_port(self, value: typing.Union[str, int, None]):
         """
         Specifies the port of the referenced service.
         """
-        self._properties["servicePort"] = None if value is None else f"{value}"
+        self._properties["servicePort"] = _types.integer_or_string(value)
 
     def __enter__(self) -> "IngressBackend":
         return self

--- a/kuber/v1_21/node_v1.py
+++ b/kuber/v1_21/node_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_21/node_v1alpha1.py
+++ b/kuber/v1_21/node_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_21/node_v1beta1.py
+++ b/kuber/v1_21/node_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import Toleration  # noqa: F401

--- a/kuber/v1_21/policy_v1beta1.py
+++ b/kuber/v1_21/policy_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import DeleteOptions  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
@@ -945,13 +946,13 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
             "selector": selector if selector is not None else LabelSelector(),
         }
         self._types = {
-            "maxUnavailable": (int, None),
-            "minAvailable": (int, None),
+            "maxUnavailable": (_types.integer_or_string, None),
+            "minAvailable": (_types.integer_or_string, None),
             "selector": (LabelSelector, None),
         }
 
     @property
-    def max_unavailable(self) -> typing.Optional[int]:
+    def max_unavailable(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at most "maxUnavailable" pods
         selected by "selector" are unavailable after the eviction,
@@ -959,8 +960,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        value = self._properties.get("maxUnavailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("maxUnavailable"),
+        )
 
     @max_unavailable.setter
     def max_unavailable(self, value: typing.Union[str, int, None]):
@@ -971,10 +974,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         can prevent all voluntary evictions by specifying 0. This is
         a mutually exclusive setting with "minAvailable".
         """
-        self._properties["maxUnavailable"] = None if value is None else f"{value}"
+        self._properties["maxUnavailable"] = _types.integer_or_string(value)
 
     @property
-    def min_available(self) -> typing.Optional[int]:
+    def min_available(self) -> typing.Union[str, int, None]:
         """
         An eviction is allowed if at least "minAvailable" pods
         selected by "selector" will still be available after the
@@ -982,8 +985,10 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        value = self._properties.get("minAvailable")
-        return int(value) if value is not None else None
+        return typing.cast(
+            typing.Union[str, int, None],
+            self._properties.get("minAvailable"),
+        )
 
     @min_available.setter
     def min_available(self, value: typing.Union[str, int, None]):
@@ -994,7 +999,7 @@ class PodDisruptionBudgetSpec(_kuber_definitions.Definition):
         for example you can prevent all voluntary evictions by
         specifying "100%".
         """
-        self._properties["minAvailable"] = None if value is None else f"{value}"
+        self._properties["minAvailable"] = _types.integer_or_string(value)
 
     @property
     def selector(self) -> "LabelSelector":

--- a/kuber/v1_21/rbac_v1.py
+++ b/kuber/v1_21/rbac_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/rbac_v1alpha1.py
+++ b/kuber/v1_21/rbac_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/rbac_v1beta1.py
+++ b/kuber/v1_21/rbac_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import LabelSelector  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401

--- a/kuber/v1_21/scheduling_v1.py
+++ b/kuber/v1_21/scheduling_v1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_21/scheduling_v1alpha1.py
+++ b/kuber/v1_21/scheduling_v1alpha1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_21/scheduling_v1beta1.py
+++ b/kuber/v1_21/scheduling_v1beta1.py
@@ -4,6 +4,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 

--- a/kuber/v1_21/storage_v1.py
+++ b/kuber/v1_21/storage_v1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_21/storage_v1alpha1.py
+++ b/kuber/v1_21/storage_v1alpha1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber/v1_21/storage_v1beta1.py
+++ b/kuber/v1_21/storage_v1beta1.py
@@ -5,6 +5,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 from kuber.v1_21.meta_v1 import ListMeta  # noqa: F401
 from kuber.v1_21.meta_v1 import ObjectMeta  # noqa: F401
 from kuber.v1_21.core_v1 import PersistentVolumeSpec  # noqa: F401

--- a/kuber_maker/parsing.py
+++ b/kuber_maker/parsing.py
@@ -14,8 +14,8 @@ TYPES = {
     # IntOrStrings must be integer values because of OpenApi v2
     # validation limitations. See issue for details:
     # https://github.com/kubernetes-client/python/issues/322
-    "IntOrString": "int",
-    "Quantity": "str",
+    "IntOrString": "_types.integer_or_string",
+    "Quantity": "_types.integer_or_string",
     None: None,
 }
 

--- a/kuber_maker/templates/module-imports.jinja2
+++ b/kuber_maker/templates/module-imports.jinja2
@@ -7,6 +7,7 @@ from kubernetes import client  # noqa: F401
 from kuber import kube_api as _kube_api  # noqa: F401
 {% endif %}
 from kuber import definitions as _kuber_definitions  # noqa: F401
+from kuber import _types  # noqa: F401
 {% for imp in imports -%}
 from {{ imp.package }} import {{ imp.target }}  # noqa: F401
 {% endfor %}
@@ -19,4 +20,3 @@ class CustomObjectStatus(dict):
         """Transparent pass-through method to match standard status objects."""
         return cls(**data)
 {% endif %}
-

--- a/kuber_maker/templates/object-class/properties.jinja2
+++ b/kuber_maker/templates/object-class/properties.jinja2
@@ -57,7 +57,7 @@
         """
         {{ v.description | printable | wordwrap(width=60) | indent(width=8) }}
         """
-        self._properties["{{ p }}"] = None if value is None else f"{value}"
+        self._properties["{{ p }}"] = _types.integer_or_string(value)
     {% elif v.data_type.api_type == "IntOrString" %}
     @{{ p | snake_case }}.setter
     def {{ p | snake_case }}(
@@ -67,7 +67,7 @@
         """
         {{ v.description | printable | wordwrap(width=60) | indent(width=8) }}
         """
-        self._properties["{{ p }}"] = None if value is None else f"{value}"
+        self._properties["{{ p }}"] = _types.integer_or_string(value)
     {% elif v.data_type.code_import and v.data_type.python_type == "list" %}
     @{{ p | snake_case }}.setter
     def {{ p | snake_case }}(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kuber"
-version = "1.15.0"
+version = "1.15.1"
 description = "Accelerated Kubernetes configuration and package management with Python."
 authors = ["Scott Ernst <swernst@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
While the Python kubernetes client has issues
with `IntOrString` data types because of their
continued use of OpenAPIV2 schema validation,
we move to make that type available in kuber
to match the expected behavior.